### PR TITLE
Update ZigZagZog.sol

### DIFF
--- a/src/ZigZagZog.sol
+++ b/src/ZigZagZog.sol
@@ -249,7 +249,7 @@ contract ZigZagZog is EIP712 {
 
         require(
             numCircles + numSquares + numTriangles == playerSurvivingPlays[gameNumber][msg.sender],
-            "ZigZagZog.revealChoices: insufficient remaining plays"
+            "ZigZagZog.revealChoices: number of revealed plays does not match surviving plays"
         );
 
         if (numCircles > 0) {


### PR DESCRIPTION
The `revealChoices` function contains a `require` block that reverts when a player reveals any number of plays that do not sum to their number of surviving plays. This PR updates the revert message to reflect the cause of the reversion.